### PR TITLE
Exclude nursery clippy (#18)

### DIFF
--- a/snowflake-api/src/lib.rs
+++ b/snowflake-api/src/lib.rs
@@ -3,7 +3,7 @@
     test(no_crate_inject)
 )]
 #![doc = include_str ! ("../README.md")]
-#![warn(clippy::all, clippy::pedantic, clippy::nursery)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::must_use_candidate,
     clippy::missing_errors_doc,


### PR DESCRIPTION
Better avoid experimental lints, unless there is a clear benefit.